### PR TITLE
[FEAT] HomeView 상단 섹션 구현 및 레이아웃 수정 (#28)

### DIFF
--- a/LINKAREER-iOS/LINKAREER-iOS.xcodeproj/project.pbxproj
+++ b/LINKAREER-iOS/LINKAREER-iOS.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BASE_URL = "https://api.linkareer.store";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZVPB55PQN5;
@@ -191,6 +192,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				BASE_URL = "https://api.linkareer.store";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = ZVPB55PQN5;
@@ -215,8 +217,6 @@
 		};
 		0D926CDC2CE8EE640053EB5B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = 0D926CC82CE8EE620053EB5B /* LINKAREER-iOS */;
-			baseConfigurationReferenceRelativePath = Global/Settings/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -280,8 +280,6 @@
 		};
 		0D926CDD2CE8EE640053EB5B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReferenceAnchor = 0D926CC82CE8EE620053EB5B /* LINKAREER-iOS */;
-			baseConfigurationReferenceRelativePath = Global/Settings/Config.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/LINKAREER-iOS/LINKAREER-iOS/Global/Extension/UIButton+.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Global/Extension/UIButton+.swift
@@ -10,11 +10,11 @@ import UIKit
 extension UIButton {
     
     func setStyle(title: String,
-                            titleColor: UIColor = .lkBlue,
-                            backgroundColor: UIColor = .blue50,
-                            font: UIFont = fontStyle.label7_m_9.font(),
-                            cornerRadius: CGFloat = 4,
-                            contentEdgeInsets: UIEdgeInsets = UIEdgeInsets(top: 4.5, left: 5, bottom: 4.5, right: 5)) {
+                  titleColor: UIColor = .lkBlue,
+                  backgroundColor: UIColor = .blue50,
+                  font: UIFont = fontStyle.label7_m_9.font(),
+                  cornerRadius: CGFloat = 4,
+                  contentEdgeInsets: UIEdgeInsets = UIEdgeInsets(top: 4.5, left: 5, bottom: 4.5, right: 5)) {
         
         self.do {
             $0.setTitle(title, for: .normal)
@@ -25,6 +25,21 @@ extension UIButton {
             $0.layer.cornerRadius = cornerRadius
             $0.contentEdgeInsets = contentEdgeInsets
         }
+    }
+    
+    func addBottomBorder(color: UIColor = .lkBlue, height: CGFloat = 4.0) {
+        removeBottomBorder() // 중복 방지
+        let borderLayer = CALayer()
+        borderLayer.backgroundColor = color.cgColor
+        borderLayer.frame = CGRect(x: 0, y: self.bounds.height - height, width: self.bounds.width, height: height)
+        borderLayer.name = "bottomBorder"
+        self.layer.addSublayer(borderLayer)
+        self.setTitleColor(color, for: .normal)
+    }
+    
+    func removeBottomBorder() {
+        self.layer.sublayers?.removeAll(where: { $0.name == "bottomBorder" })
+        self.setTitleColor(.gray900, for: .normal)
     }
 }
 

--- a/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/SegmentStackView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/SegmentStackView.swift
@@ -124,6 +124,10 @@ extension SegmentStackView {
             stackView.addArrangedSubview(tagButton)
         }
     }
+    
+    func getButtons() -> [UIButton] {
+        return tagButtons
+    }
 }
 
 

--- a/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/SegmentStackView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/SegmentStackView.swift
@@ -1,0 +1,129 @@
+//
+//  SegmentStackView.swift
+//  LINKAREER-iOS
+//
+//  Created by 김민서 on 11/26/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+class SegmentStackView: UIView {
+    
+    // MARK: - UI Properties
+    
+    private let scrollView: UIScrollView = UIScrollView()
+    private let stackView: UIStackView = UIStackView()
+    
+    private let arrowDownButton: UIButton = UIButton()
+    
+    private let lineView: UIView = UIView()
+    
+    // MARK: - Properties
+    
+    private var tagButtons: [UIButton] = []
+    
+    let tagTexts: [String] = [
+        "신입/인턴", "대외활동/교육/공모전", "채널", "커뮤니티", "멘토 게시판", "자기소개서", "스펙 정리하기"
+    ]
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setHierarchy()
+        setLayout()
+        setStyle()
+        setCategoryList()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    
+    func setHierarchy() {
+        self.addSubviews(lineView, scrollView, arrowDownButton, lineView)
+        scrollView.addSubview(stackView)
+    }
+    
+    func setLayout() {
+        scrollView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(scrollView).offset(16)
+            $0.trailing.equalTo(scrollView).offset(-16)
+        }
+        
+        arrowDownButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.trailing.equalToSuperview().inset(14)
+            $0.size.equalTo(30)
+        }
+        
+        lineView.snp.makeConstraints {
+            $0.bottom.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+        
+    }
+    
+    func setStyle() {
+        scrollView.do {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            $0.showsHorizontalScrollIndicator = false
+            $0.alwaysBounceHorizontal = true
+        }
+        
+        stackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 20
+            $0.alignment = .fill
+            $0.distribution = .fill
+        }
+        
+        arrowDownButton.do {
+            $0.setImage(.icArrowDown24, for: .normal)
+            $0.backgroundColor = .lkWhite
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.gray300.cgColor
+            $0.layer.cornerRadius = 2
+        }
+        
+        lineView.backgroundColor = .gray300
+    }
+    
+}
+
+extension SegmentStackView {
+    
+    private func setCategoryList() {
+        for tagText in tagTexts {
+            let tagButton: UIButton = UIButton()
+            
+            tagButton.do {
+                $0.setTitle(tagText, for: .normal)
+                $0.setTitleColor(.gray900, for: .normal)
+                $0.titleLabel?.font = fontStyle.title3_b_16.font()
+                $0.tag = tagButtons.count // 버튼의 index를 tag로 설정
+            }
+            
+            tagButton.snp.makeConstraints {
+                $0.height.equalTo(48)
+            }
+            
+            tagButtons.append(tagButton)
+            stackView.addArrangedSubview(tagButton)
+        }
+    }
+}
+
+

--- a/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/TagHeaderView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Global/UIComponents/TagHeaderView.swift
@@ -42,7 +42,8 @@ class TagHeaderView: UICollectionReusableView {
     
     func setLayout() {
         nickNameLabel.snp.makeConstraints {
-            $0.top.leading.equalToSuperview()
+            $0.top.equalToSuperview().inset(24)
+            $0.leading.equalToSuperview()
         }
         
         titleLabel.snp.makeConstraints {
@@ -61,7 +62,8 @@ class TagHeaderView: UICollectionReusableView {
         }
         
         moreButton.snp.makeConstraints {
-            $0.verticalEdges.trailing.equalToSuperview()
+            $0.bottom.equalTo(tagStackView).inset(15)
+            $0.trailing.equalToSuperview()
             $0.width.equalTo(43)
         }
     }

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/Cell/HomeBannerCell.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/Cell/HomeBannerCell.swift
@@ -111,7 +111,7 @@ final class HomeBannerCell: UICollectionViewCell {
         }
         
         titleLabel.do {
-            $0.setLabel(alignment: .left, textColor: .gray900, font: fontStyle.body2_b_14.font())
+            $0.setLabel(alignment: .left, numberOfLines: 1, textColor: .gray900, font: fontStyle.body2_b_14.font())
         }
         
         benefitTagButton.do {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
@@ -18,6 +18,8 @@ class HomeView: UIView {
     
     lazy var mainCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createCompositionalLayout())
     
+    let segmentStackView = SegmentStackView()
+    
     // MARK: - UI Properties
     
     private var homeSection: [HomeSection] = HomeSection.dataSource
@@ -38,7 +40,7 @@ class HomeView: UIView {
     
     
     func setHierarchy() {
-        self.addSubviews(mainCollectionView, searchBarView)
+        self.addSubviews(mainCollectionView, segmentStackView, searchBarView)
     }
     
     func setLayout() {
@@ -47,8 +49,14 @@ class HomeView: UIView {
             $0.horizontalEdges.equalToSuperview()
         }
         
-        mainCollectionView.snp.makeConstraints {
+        segmentStackView.snp.makeConstraints {
             $0.top.equalTo(searchBarView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(48)
+        }
+        
+        mainCollectionView.snp.makeConstraints {
+            $0.top.equalTo(segmentStackView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
@@ -14,6 +14,8 @@ class HomeView: UIView {
     
     // MARK: - UI Properties
     
+    private let searchBarView = CustomSearchView()
+    
     lazy var mainCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: self.createCompositionalLayout())
     
     // MARK: - UI Properties
@@ -36,12 +38,17 @@ class HomeView: UIView {
     
     
     func setHierarchy() {
-        self.addSubview(mainCollectionView)
+        self.addSubviews(mainCollectionView, searchBarView)
     }
     
     func setLayout() {
+        searchBarView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+        }
+        
         mainCollectionView.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(24)
+            $0.top.equalTo(searchBarView.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
@@ -80,16 +80,21 @@ extension HomeView {
         let layout = UICollectionViewCompositionalLayout { sectionIndex, _ -> NSCollectionLayoutSection? in
             switch self.homeSection[sectionIndex] {
             case .homeBanner:
-                return self.setHomeBannerLayout()
+                let section = self.setHomeBannerLayout()
+                section.decorationItems = [
+                    .background(elementKind: SectionBackgroundView.identifier)
+                ]
+                return section
             case .catecoryBoard:
                 return self.setCategorySelectorLayout()
             case .interestBoard:
                 return self.setInterestBoardLayout()
             case .recommendRecruit:
                 return self.setRecommendRecruitLayout()
-           
+                
             }
         }
+
         return layout
     }
     
@@ -100,31 +105,33 @@ extension HomeView {
 
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(273))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        
+
         let section = NSCollectionLayoutSection(group: group)
         section.orthogonalScrollingBehavior = .groupPaging
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [self.setHeaderView(), self.setBottomPageControlView()]
+        section.decorationItems = [.background(elementKind: SectionBackgroundView.identifier)] // 배경 추가
         
         return section
     }
+
     
     func setCategorySelectorLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .estimated(40), heightDimension: .fractionalHeight(1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
+        
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(36))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 0)
         group.interItemSpacing = .fixed(8)
-
+        
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [self.setHeaderView()]
-
+        
         return section
     }
-
+    
     
     func setInterestBoardLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(152))
@@ -148,7 +155,7 @@ extension HomeView {
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(142 + 8), heightDimension: .absolute(252))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
+        
         let section = NSCollectionLayoutSection(group: group)
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 14, bottom: 65, trailing: 6) // 섹션의 여백 설정
         section.orthogonalScrollingBehavior = .continuous
@@ -156,7 +163,7 @@ extension HomeView {
         
         return section
     }
-
+    
     
     func setHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(75))

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
@@ -48,7 +48,7 @@ class HomeView: UIView {
         }
         
         mainCollectionView.snp.makeConstraints {
-            $0.top.equalTo(searchBarView.snp.bottom).offset(24)
+            $0.top.equalTo(searchBarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalToSuperview()
         }
@@ -127,7 +127,7 @@ extension HomeView {
         group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 14)
         
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 24, trailing: 0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 0, trailing: 0)
         section.boundarySupplementaryItems = [self.setHeaderView()]
         
         return section
@@ -150,7 +150,7 @@ extension HomeView {
     }
     
     func setHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {
-        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(51))
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(75))
         let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: TagHeaderView.identifier, alignment: .top)
         header.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 14)
         
@@ -158,7 +158,7 @@ extension HomeView {
     }
     
     func setBottomPageControlView() -> NSCollectionLayoutBoundarySupplementaryItem {
-        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(78))
+        let footerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(54))
         let footer = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: footerSize, elementKind: BottomPageControlView.identifier, alignment: .bottom)
         
         return footer

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/HomeView.swift
@@ -142,20 +142,21 @@ extension HomeView {
     }
     
     func setRecommendRecruitLayout() -> NSCollectionLayoutSection {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(142), heightDimension: .absolute(252)) // 아이템 크기
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 40)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(142), heightDimension: .absolute(252))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(142 + 8), heightDimension: .absolute(252))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-        group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 14, bottom: 0, trailing: 14)
-        
+
         let section = NSCollectionLayoutSection(group: group)
-        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 65, trailing: 0)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 14, bottom: 65, trailing: 6) // 섹션의 여백 설정
         section.orthogonalScrollingBehavior = .continuous
-        section.boundarySupplementaryItems = [ self.setPolicyFooterView()]
+        section.boundarySupplementaryItems = [self.setPolicyFooterView()]
         
         return section
     }
+
     
     func setHeaderView() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .absolute(75))

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/SectionBackgroundView.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/View/SectionBackgroundView.swift
@@ -1,0 +1,22 @@
+//
+//  SectionBackgroundView.swift
+//  LINKAREER-iOS
+//
+//  Created by 김민서 on 11/26/24.
+//
+
+import UIKit
+
+class SectionBackgroundView: UICollectionReusableView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.backgroundColor = .blue50
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -25,6 +25,8 @@ class HomeViewController: UIViewController {
     private var homeBanners: [HomeBanner] = HomeBanner.dummyData
     private var interestBoard: [Board] = Board.dummyData
     
+    private var isInternScreenShown = false
+    
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
@@ -35,6 +37,7 @@ class HomeViewController: UIViewController {
         setStyle()
         registerCell()
         setDelegate()
+        setActions()
     }
     
     func setHierarchy() {
@@ -67,7 +70,50 @@ class HomeViewController: UIViewController {
         }
     }
     
+    
+    func setActions() {
+        let buttons = homeView.segmentStackView.getButtons()
+        for button in buttons {
+            button.addTarget(self, action: #selector(handleButtonTap(_:)), for: .touchUpInside)
+        }
+    }
+    
+    @objc
+    func handleButtonTap(_ sender: UIButton) {
+        let tagText = homeView.segmentStackView.tagTexts[sender.tag] // 버튼 텍스트 확인
+        
+        if tagText == "신입/인턴" {
+            isInternScreenShown.toggle() // 상태 변경
+            
+            if isInternScreenShown {
+                addBottomBorder(to: sender)
+                print("신입/인턴 화면으로 전환!") // 화면 전환 로직
+            } else {
+                print("원래 화면으로 복귀!") // 복귀 로직
+                removeBottomBorder(from: sender)
+            }
+        }
+    }
+    
 }
+
+extension HomeViewController {
+    
+    func addBottomBorder(to button: UIButton) {
+        let borderLayer = CALayer()
+        borderLayer.backgroundColor = UIColor.lkBlue.cgColor
+        borderLayer.frame = CGRect(x: 0, y: button.frame.height - 4, width: button.frame.width, height: 4)
+        borderLayer.name = "bottomBorder"
+        button.layer.addSublayer(borderLayer)
+        button.setTitleColor(.lkBlue, for: .normal)
+    }
+    
+    func removeBottomBorder(from button: UIButton) {
+        button.layer.sublayers?.removeAll(where: { $0.name == "bottomBorder" })
+        button.setTitleColor(.gray900, for: .normal)
+    }
+}
+
 
 extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSource {
     
@@ -102,7 +148,7 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
                 fatalError("Unable to dequeue CategorySelectorCell")
             }
             let category = categorySelector[indexPath.row]
-            let isSelected = indexPath.row == 0 
+            let isSelected = indexPath.row == 0
             cell.configure(with: category, isSelected: isSelected)
             return cell
         case .interestBoard, .recommendRecruit:

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -16,6 +16,8 @@ class HomeViewController: UIViewController {
     
     private let homeView: HomeView = HomeView()
     
+    
+    
     // MARK: - Properties
     
     private let dataSource: [HomeSection] = HomeSection.dataSource

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -16,8 +16,6 @@ class HomeViewController: UIViewController {
     
     private let homeView: HomeView = HomeView()
     
-    
-    
     // MARK: - Properties
     
     private let dataSource: [HomeSection] = HomeSection.dataSource

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -69,11 +69,10 @@ class HomeViewController: UIViewController {
             $0.register(TagHeaderView.self, forSupplementaryViewOfKind: TagHeaderView.identifier, withReuseIdentifier: TagHeaderView.identifier)
             $0.register(BottomPageControlView.self, forSupplementaryViewOfKind: BottomPageControlView.identifier, withReuseIdentifier: BottomPageControlView.identifier)
             $0.register(PolicyFooterView.self, forSupplementaryViewOfKind: PolicyFooterView.identifier, withReuseIdentifier: PolicyFooterView.identifier)
+            $0.collectionViewLayout.register(SectionBackgroundView.self, forDecorationViewOfKind: SectionBackgroundView.identifier)
         }
     }
-    
-    
-    
+
     func setActions() {
         let buttons = homeView.segmentStackView.getButtons()
         for button in buttons {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -24,6 +24,7 @@ class HomeViewController: UIViewController {
     private var categorySelector: [CategorySelector] = CategorySelector.dummyData
     private var homeBanners: [HomeBanner] = HomeBanner.dummyData
     private var interestBoard: [Board] = Board.dummyData
+    private var recommendRecruit = CompanyDayCardModelData.shared.allCard
     
     private var isInternScreenShown = false
     
@@ -64,11 +65,13 @@ class HomeViewController: UIViewController {
             $0.register(HomeBannerCell.self, forCellWithReuseIdentifier: HomeBannerCell.identifier)
             $0.register(BoardCell.self, forCellWithReuseIdentifier: BoardCell.identifier)
             $0.register(CategorySelectorCell.self, forCellWithReuseIdentifier: CategorySelectorCell.identifier)
+            $0.register(CompanyDayCardCell.self, forCellWithReuseIdentifier: CompanyDayCardCell.identifier)
             $0.register(TagHeaderView.self, forSupplementaryViewOfKind: TagHeaderView.identifier, withReuseIdentifier: TagHeaderView.identifier)
             $0.register(BottomPageControlView.self, forSupplementaryViewOfKind: BottomPageControlView.identifier, withReuseIdentifier: BottomPageControlView.identifier)
             $0.register(PolicyFooterView.self, forSupplementaryViewOfKind: PolicyFooterView.identifier, withReuseIdentifier: PolicyFooterView.identifier)
         }
     }
+    
     
     
     func setActions() {
@@ -130,7 +133,7 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
         case .interestBoard:
             return interestBoard.count
         case .recommendRecruit:
-            return interestBoard.count
+            return recommendRecruit.count
         }
     }
     
@@ -151,14 +154,33 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
             let isSelected = indexPath.row == 0
             cell.configure(with: category, isSelected: isSelected)
             return cell
-        case .interestBoard, .recommendRecruit:
+        case .interestBoard:
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoardCell.identifier, for: indexPath) as? BoardCell else {
                 fatalError("Unable to dequeue BoardCell")
             }
             let board = interestBoard[indexPath.row]
             cell.configure(with: board)
             return cell
+            
+        case .recommendRecruit:
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CompanyDayCardCell.identifier, for: indexPath) as? CompanyDayCardCell else {
+                fatalError("Unable to dequeue CompanyDayCardCell")
+            }
+            let item = recommendRecruit[indexPath.item]
+            
+            cell.configure(
+                day: item.day,
+                image: item.image,
+                buttonTitle: item.buttonTitle,
+                companyName: item.companyName,
+                title: item.title,
+                category: item.category,
+                viewCount: item.viewCount,
+                commentCount: item.commentCount
+            )
+            return cell
         }
+        
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/Home/ViewController/HomeViewController.swift
@@ -102,19 +102,14 @@ class HomeViewController: UIViewController {
 extension HomeViewController {
     
     func addBottomBorder(to button: UIButton) {
-        let borderLayer = CALayer()
-        borderLayer.backgroundColor = UIColor.lkBlue.cgColor
-        borderLayer.frame = CGRect(x: 0, y: button.frame.height - 4, width: button.frame.width, height: 4)
-        borderLayer.name = "bottomBorder"
-        button.layer.addSublayer(borderLayer)
-        button.setTitleColor(.lkBlue, for: .normal)
+        button.addBottomBorder(color: .lkBlue, height: 4.0)
     }
     
     func removeBottomBorder(from button: UIButton) {
-        button.layer.sublayers?.removeAll(where: { $0.name == "bottomBorder" })
-        button.setTitleColor(.gray900, for: .normal)
+        button.removeBottomBorder()
     }
 }
+
 
 
 extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSource {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/NewBieIntern/View/Section2/CompanyDayCardCell.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/NewBieIntern/View/Section2/CompanyDayCardCell.swift
@@ -149,8 +149,7 @@ class CompanyDayCardCell: UICollectionViewCell {
         }
         
         logoImageView.snp.makeConstraints {
-            $0.centerX.equalTo(boxView)
-            $0.centerY.equalTo(boxView)
+            $0.center.equalTo(boxView)
         }
         
         actionButton.snp.makeConstraints {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/NewBieIntern/View/Section2/CompanyDayCardCell.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/NewBieIntern/View/Section2/CompanyDayCardCell.swift
@@ -149,10 +149,8 @@ class CompanyDayCardCell: UICollectionViewCell {
         }
         
         logoImageView.snp.makeConstraints {
-            $0.centerX.equalTo(boxView.snp.centerX)
-            $0.centerY.equalTo(boxView.snp.centerY)
-            $0.size.equalTo(142)
-
+            $0.centerX.equalTo(boxView)
+            $0.centerY.equalTo(boxView)
         }
         
         actionButton.snp.makeConstraints {
@@ -185,11 +183,7 @@ class CompanyDayCardCell: UICollectionViewCell {
             $0.centerY.equalTo(viewCountLabel)
             $0.leading.equalTo(viewCountLabel.snp.trailing).offset(3)
         }
-        
-        snp.makeConstraints {
-            $0.height.equalTo(255)
-            $0.width.equalTo(142)
-        }
+
     }
 }
 extension CompanyDayCardCell {

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/TabBar/TabBarController.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/TabBar/TabBarController.swift
@@ -22,7 +22,9 @@ final class TabBarController: UITabBarController {
         
         setupStyle()
         addTabBarController()
+        self.selectedIndex = TabBarItem.allCases.firstIndex(of: .home) ?? 0
     }
+
 }
 
 private extension TabBarController {
@@ -43,6 +45,7 @@ private extension TabBarController {
             )
             return currentViewController
         }
+
         setViewControllers(viewControllers, animated: false)
     }
     

--- a/LINKAREER-iOS/LINKAREER-iOS/Presentation/TabBar/TabBarItem.swift
+++ b/LINKAREER-iOS/LINKAREER-iOS/Presentation/TabBar/TabBarItem.swift
@@ -67,7 +67,7 @@ enum TabBarItem: CaseIterable {
         case .community:
             return HomeViewController()
         case .home:
-            return HomeViewController()
+            return CustomNavigationController(rootViewController: HomeViewController())
         case .calendar:
             return HomeViewController()
         case .chat:


### PR DESCRIPTION
# 🔥 *Pull requests*

## ⛳️ **작업한 브랜치**
- feature/#28

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
 - 레이아웃 수정
 - 배너 cell background Color 적용
 - 네비바 적용
 - 상단 섹션 구현
 
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
### 💌 To. 취남 재현
SegmentStackView만들어두었습니다!
1. 튀는걸이 만든 `NavigationBar` 적용하기
2. 튀는걸이 만든 `CustomSearchView` 적용하기
3. 깜찍걸이 만든  `SegmentStackView` CustomSearchView 밑에 붙이기!

→ 요렇게 해두면 화면 전환은 제가 하고 PR때 자세히 설명해드릴게요!!

HomeView에 구현해놨으니! 이거 보고 해보다가 헷갈리는거 있으면 언제든 질문 콜링
indicator는 후순위로 두고 API 연결 후 시간 되면 구현하도록 하겠습니다ㅠㅠㅠ
## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|아이폰15Pro|![Simulator Screen Recording - iPhone 13 mini - 2024-11-26 at 12 16 56](https://github.com/user-attachments/assets/0fa9d3b8-ab5e-4218-a414-7e6f71509411)|


## 💫 관련 이슈
- Resolved: #28 
